### PR TITLE
Add Codecov configuration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,6 @@
 coverage:
   status:
-    project: # coverage of whole project including changes in patch
+    project: # coverage of project
       default:
         target: 60% # project coverage must be maintained at 60% or higher
     patch: # coverage of lines changed in patch

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,6 +3,7 @@ coverage:
     project: # coverage of project
       default:
         target: 60% # project coverage must be maintained at 60% or higher
+        threshold: 5% # allow project coverage to drop by at most 5%
     patch: # coverage of lines changed in patch
       default:
         target: 0% # no requirement on patch coverage

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,8 +2,7 @@ coverage:
   status:
     project: # coverage of whole project including changes in patch
       default:
-        target: auto # current coverage
-        threshold: 5 # allows coverage to drop by at most 5%
+        target: 60% # project coverage must be maintained at 60% or higher
     patch: # coverage of lines changed in patch
       default:
-        target: 40% # 40% of lines per patch must be covered
+        target: 0% # no requirement on patch coverage

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project: # coverage of whole project including changes in patch
+      default:
+        target: auto # current coverage
+        threshold: 5 # allows coverage to drop by at most 5%
+    patch: # coverage of lines changed in patch
+      default:
+        target: 40% # 40% of lines per patch must be covered


### PR DESCRIPTION
The default Codecov configuration requires patch coverage to be at least as high as the project coverage (currently around 75.26%). This requirement is too strict for our purposes, so this change removes the patch coverage requirement, and sets the project coverage requirement to 60%.