### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ src/test/data/sandbox/
 .DS_Store
 docs/_site/
 docs/_markbind/logs/
+bin/
+
+# Skip java .class files
+*.class


### PR DESCRIPTION
Currently, git tracks adds all data files in `bin/` and `.class` java-compiled files. Accidentally doing `git add .` would commit all of such files.

This PR updates gitignore to prevent such mistakes