### PR TITLE
Fix checkstyle to support lambda-style switch

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -37,6 +37,12 @@
   <!-- All Java AST specific tests live under TreeWalker module. -->
   <module name="TreeWalker">
 
+    <!-- Suppresses indentation check for lambda-style switch statements -->
+    <module name="SuppressionXpathSingleFilter">
+      <property name="checks" value="Indentation"/>
+      <property name="query" value="//SWITCH_RULE/descendant-or-self::node()"/>
+    </module>
+
     <!-- Required to allow exceptions in code style -->
     <module name="SuppressionCommentFilter">
       <property name="offCommentFormat" value="CHECKSTYLE.OFF\: ([\w\|]+)"/>


### PR DESCRIPTION
(not part of v1.1, just something I wanted to fix)

The current checkstyle configuration doesn't support the correct indentation level for lambda-style switch statements. This change implements the fix described in https://github.com/nus-cs2103-AY2425S2/forum/issues/122