### PR TITLE
Bug fix: Check duplicate keys when loading attributes from files

### DIFF
--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -75,8 +75,14 @@ class JsonAdaptedPerson {
         }
 
         final List<Attribute> personAttributes = new ArrayList<>();
+        final Set<String> attributeNames = new HashSet<>();
         for (JsonAdaptedAttribute attribute : attributes) {
             personAttributes.add(attribute.toModelType());
+            attributeNames.add(attribute.getAttributeName().toLowerCase());
+        }
+
+        if (attributeNames.size() != personAttributes.size()) {
+            throw new IllegalValueException(Attribute.NO_DUPLICATES);
         }
 
         if (name == null) {


### PR DESCRIPTION
Fixes #63

Branched from #81 to have `Attribute.NO_DUPLICATES`.

To merge after #81 is merged.