### PR TITLE
Add sort by attribute command

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -19,6 +19,7 @@ public class Messages {
     public static final String MESSAGE_PERSONS_FILTERED_OVERVIEW = "%1$d persons match all the attributes!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
+    public static final String MESSAGE_PERSONS_SORTED_OVERVIEW = "All persons sorted!";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -16,7 +16,7 @@ public class SortCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Sort the candidates with the provided attribute provided attribute name."
             + "Candidates lacking the specified attribute name will be placed last, preserving their original order.\n"
-            + "Parameters: ATTRIBUTE_NAME (case-sensitive)\n"
+            + "Parameters: ATTRIBUTE_NAME (case-insensitive)\n"
             + "Example: " + COMMAND_WORD + " a/Graduation Year";
     private final String attributeName;
 
@@ -36,7 +36,6 @@ public class SortCommand extends Command {
         model.sortFilteredPersonList(new AttributeSortComparator(this.attributeName));
 
         return new CommandResult(
-
                 String.format(Messages.MESSAGE_PERSONS_SORTED_OVERVIEW
                 ));
     }

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -1,0 +1,43 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.AttributeSortComparator;
+
+/**
+ * Sort the candidates with the provided attribute.
+ * Guarantees: immutable.
+ */
+public class SortCommand extends Command {
+    public static final String COMMAND_WORD = "sort";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Sort the candidates with the provided attribute provided attribute name."
+            + "Candidates lacking the specified attribute name will be placed last, preserving their original order.\n"
+            + "Parameters: ATTRIBUTE_NAME (case-sensitive)\n"
+            + "Example: " + COMMAND_WORD + "a/Graduation Year";
+    private final AttributeSortComparator sorter;
+
+    /**
+     * Initializes an instance with the comparator based on the attribute name.
+     *
+     * @param sorter The comparator created with the user input attribute name.
+     */
+    public SortCommand(AttributeSortComparator sorter) {
+        requireNonNull(sorter);
+        this.sorter = sorter;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        model.updateSortedPersonList(sorter);
+
+        return new CommandResult(
+                String.format(Messages.MESSAGE_PERSONS_SORTED_OVERVIEW
+                ));
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -17,27 +17,35 @@ public class SortCommand extends Command {
             + ": Sort the candidates with the provided attribute provided attribute name."
             + "Candidates lacking the specified attribute name will be placed last, preserving their original order.\n"
             + "Parameters: ATTRIBUTE_NAME (case-sensitive)\n"
-            + "Example: " + COMMAND_WORD + "a/Graduation Year";
-    private final AttributeSortComparator sorter;
+            + "Example: " + COMMAND_WORD + " a/Graduation Year";
+    private final String attributeName;
 
     /**
      * Initializes an instance with the comparator based on the attribute name.
      *
-     * @param sorter The comparator created with the user input attribute name.
+     * @param attributeName The name of the attribute to sort the user input.
      */
-    public SortCommand(AttributeSortComparator sorter) {
-        requireNonNull(sorter);
-        this.sorter = sorter;
+    public SortCommand(String attributeName) {
+        requireNonNull(attributeName);
+        this.attributeName = attributeName;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-
-        model.updateSortedPersonList(sorter);
+        model.sortFilteredPersonList(new AttributeSortComparator(this.attributeName));
 
         return new CommandResult(
+
                 String.format(Messages.MESSAGE_PERSONS_SORTED_OVERVIEW
                 ));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other instanceof SortCommand) {
+            return this.attributeName.equals(((SortCommand) other).attributeName);
+        }
+        return false;
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -18,6 +18,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -80,6 +81,9 @@ public class AddressBookParser {
 
         case AttributeRemoveCommand.COMMAND_WORD:
             return new AttributeRemoveCommandParser().parse(arguments);
+
+        case SortCommand.COMMAND_WORD:
+            return new SortCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -1,0 +1,4 @@
+package seedu.address.logic.parser;
+
+public class SortCommandParser {
+}

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -6,9 +6,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ATTRIBUTE;
 
 import java.util.List;
 
-import seedu.address.commons.core.index.Index;
-import seedu.address.commons.exceptions.IllegalValueException;
-import seedu.address.logic.commands.AttributeRemoveCommand;
 import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -1,4 +1,38 @@
 package seedu.address.logic.parser;
 
-public class SortCommandParser {
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ATTRIBUTE;
+
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.logic.commands.AttributeRemoveCommand;
+import seedu.address.logic.commands.SortCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new AttributeRemoveCommand object
+ */
+public class SortCommandParser implements Parser<SortCommand> {
+
+    @Override
+    public SortCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+
+        args = args.trim();
+
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_ATTRIBUTE);
+
+        List<String> attributes = argMultimap.getAllValues(PREFIX_ATTRIBUTE);
+
+        if (attributes.size() != 1) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    SortCommand.MESSAGE_USAGE));
+        }
+
+        return new SortCommand(attributes.get(0));
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -25,7 +25,7 @@ public class SortCommandParser implements Parser<SortCommand> {
 
         List<String> attributes = argMultimap.getAllValues(PREFIX_ATTRIBUTE);
 
-        if (attributes.size() != 1) {
+        if (attributes.isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     SortCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -2,6 +2,7 @@ package seedu.address.model;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Comparator;
 import java.util.List;
 
 import javafx.collections.ObservableList;
@@ -84,6 +85,11 @@ public class AddressBook implements ReadOnlyAddressBook {
         requireNonNull(editedPerson);
 
         persons.setPerson(target, editedPerson);
+    }
+
+    public void sortPersons(Comparator<Person> comparator) {
+        requireNonNull(comparator);
+        persons.sortPersons(comparator);
     }
 
     /**

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -87,8 +87,13 @@ public class AddressBook implements ReadOnlyAddressBook {
         persons.setPerson(target, editedPerson);
     }
 
+    /**
+     * Sorts persons in the AddressBook by the given {@code comparator}.
+     */
+
     public void sortPersons(Comparator<Person> comparator) {
         requireNonNull(comparator);
+
         persons.sortPersons(comparator);
     }
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -6,7 +6,6 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
-import seedu.address.model.attribute.Attribute;
 import seedu.address.model.person.AttributeSortComparator;
 import seedu.address.model.person.Person;
 
@@ -88,12 +87,9 @@ public interface Model {
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
 
-    /** Returns an unmodifiable view of the sorted person list */
-    ObservableList<Person> getSortedPersonList();
-
     /**
-     * Updates the attributeToSort of the sorted person list to the given {@code attributeToSort}.
-     * @throws NullPointerException if {@code attributeToSort} is null.
+     * Sorts the filtered person list by the given {@code comparator}.
+     * @throws NullPointerException if {@code comparator} is null.
      */
-    void updateSortedPersonList(Comparator<Person> sorter);
+    void sortFilteredPersonList(Comparator<Person> comparator);
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -6,7 +6,6 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
-import seedu.address.model.person.AttributeSortComparator;
 import seedu.address.model.person.Person;
 
 /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,10 +1,13 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.attribute.Attribute;
+import seedu.address.model.person.AttributeSortComparator;
 import seedu.address.model.person.Person;
 
 /**
@@ -84,4 +87,13 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+    /** Returns an unmodifiable view of the sorted person list */
+    ObservableList<Person> getSortedPersonList();
+
+    /**
+     * Updates the attributeToSort of the sorted person list to the given {@code attributeToSort}.
+     * @throws NullPointerException if {@code attributeToSort} is null.
+     */
+    void updateSortedPersonList(Comparator<Person> sorter);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -5,15 +5,17 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
 import java.util.Comparator;
+import java.util.List;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
+import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import javafx.collections.transformation.SortedList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.model.attribute.Attribute;
 import seedu.address.model.person.Person;
 
 /**
@@ -25,7 +27,6 @@ public class ModelManager implements Model {
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
-    private final SortedList<Person> sortedPersons;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -37,8 +38,7 @@ public class ModelManager implements Model {
 
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
-        filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
-        sortedPersons = new SortedList<>(this.addressBook.getPersonList());
+        this.filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
     }
 
     public ModelManager() {
@@ -133,17 +133,12 @@ public class ModelManager implements Model {
         filteredPersons.setPredicate(predicate);
     }
 
-    //=========== Sorted Person List Accessors =============================================================
-
+    /**
+     * Sorts filteredPerson with a given comparator.
+     */
     @Override
-    public ObservableList<Person> getSortedPersonList() {
-        return sortedPersons;
-    }
-
-    @Override
-    public void updateSortedPersonList(Comparator<Person> sorter) {
-        requireNonNull(sorter);
-        sortedPersons.setComparator(sorter);
+    public void sortFilteredPersonList(Comparator<Person> comparator) {
+        addressBook.sortPersons(comparator);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -5,15 +5,11 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
 import java.util.Comparator;
-import java.util.List;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
-import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
-import javafx.collections.transformation.SortedList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.person.Person;
@@ -48,14 +44,14 @@ public class ModelManager implements Model {
     //=========== UserPrefs ==================================================================================
 
     @Override
-    public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
-        requireNonNull(userPrefs);
-        this.userPrefs.resetData(userPrefs);
+    public ReadOnlyUserPrefs getUserPrefs() {
+        return userPrefs;
     }
 
     @Override
-    public ReadOnlyUserPrefs getUserPrefs() {
-        return userPrefs;
+    public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
+        requireNonNull(userPrefs);
+        this.userPrefs.resetData(userPrefs);
     }
 
     @Override
@@ -83,13 +79,13 @@ public class ModelManager implements Model {
     //=========== AddressBook ================================================================================
 
     @Override
-    public void setAddressBook(ReadOnlyAddressBook addressBook) {
-        this.addressBook.resetData(addressBook);
+    public ReadOnlyAddressBook getAddressBook() {
+        return addressBook;
     }
 
     @Override
-    public ReadOnlyAddressBook getAddressBook() {
-        return addressBook;
+    public void setAddressBook(ReadOnlyAddressBook addressBook) {
+        this.addressBook.resetData(addressBook);
     }
 
     @Override
@@ -148,11 +144,10 @@ public class ModelManager implements Model {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof ModelManager)) {
+        if (!(other instanceof ModelManager otherModelManager)) {
             return false;
         }
 
-        ModelManager otherModelManager = (ModelManager) other;
         return addressBook.equals(otherModelManager.addressBook)
                 && userPrefs.equals(otherModelManager.userPrefs)
                 && filteredPersons.equals(otherModelManager.filteredPersons);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,13 +4,16 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
+import javafx.collections.transformation.SortedList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.attribute.Attribute;
 import seedu.address.model.person.Person;
 
 /**
@@ -22,6 +25,7 @@ public class ModelManager implements Model {
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
+    private final SortedList<Person> sortedPersons;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -34,6 +38,7 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
+        sortedPersons = new SortedList<>(this.addressBook.getPersonList());
     }
 
     public ModelManager() {
@@ -126,6 +131,19 @@ public class ModelManager implements Model {
     public void updateFilteredPersonList(Predicate<Person> predicate) {
         requireNonNull(predicate);
         filteredPersons.setPredicate(predicate);
+    }
+
+    //=========== Sorted Person List Accessors =============================================================
+
+    @Override
+    public ObservableList<Person> getSortedPersonList() {
+        return sortedPersons;
+    }
+
+    @Override
+    public void updateSortedPersonList(Comparator<Person> sorter) {
+        requireNonNull(sorter);
+        sortedPersons.setComparator(sorter);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/attribute/Attribute.java
+++ b/src/main/java/seedu/address/model/attribute/Attribute.java
@@ -46,7 +46,7 @@ public class Attribute {
         }
 
         if (other instanceof Attribute attribute) {
-            return this.matchesName(attribute.attributeName)
+            return attributeName.equalsIgnoreCase(attribute.attributeName)
                     && attributeValue.equals(attribute.attributeValue);
         }
 
@@ -70,7 +70,7 @@ public class Attribute {
      * @return 0 if they have the same attribute value, -1 if attribute1 has a smaller value, 1 otherwise
      */
     public int compareToAttributeOfSameAttributeName(Attribute other) {
-        assert this.attributeName.equals(other.attributeName);
+        assert this.matchesName(other.attributeName);
         return this.attributeValue.compareTo(other.attributeValue);
     }
 

--- a/src/main/java/seedu/address/model/attribute/Attribute.java
+++ b/src/main/java/seedu/address/model/attribute/Attribute.java
@@ -46,7 +46,7 @@ public class Attribute {
         }
 
         if (other instanceof Attribute attribute) {
-            return attributeName.equalsIgnoreCase(attribute.attributeName)
+            return this.matchesName(attribute.attributeName)
                     && attributeValue.equals(attribute.attributeValue);
         }
 

--- a/src/main/java/seedu/address/model/attribute/Attribute.java
+++ b/src/main/java/seedu/address/model/attribute/Attribute.java
@@ -63,6 +63,17 @@ public class Attribute {
         return attributeName.equalsIgnoreCase(name);
     }
 
+    /**
+     * Compare to another attributes with the same attribute name by their attribute value.
+     *
+     * @param other The other attribute to compare with
+     * @return 0 if they have the same attribute value, -1 if attribute1 has a smaller value, 1 otherwise
+     */
+    public int compareToAttributeOfSameAttributeName(Attribute other) {
+        assert this.attributeName.equals(other.attributeName);
+        return this.attributeValue.compareTo(other.attributeValue);
+    }
+
     @Override
     public int hashCode() {
         return attributeName.hashCode();

--- a/src/main/java/seedu/address/model/person/AttributeSortComparator.java
+++ b/src/main/java/seedu/address/model/person/AttributeSortComparator.java
@@ -5,6 +5,11 @@ import java.util.Optional;
 
 import seedu.address.model.attribute.Attribute;
 
+/**
+ * Compare two persons based on the lexicographical order of the value of a specified attribute name.
+ * Guarantees: immutable.
+ */
+
 public class AttributeSortComparator implements Comparator<Person> {
     private final String attributeName;
 

--- a/src/main/java/seedu/address/model/person/AttributeSortComparator.java
+++ b/src/main/java/seedu/address/model/person/AttributeSortComparator.java
@@ -1,0 +1,34 @@
+package seedu.address.model.person;
+
+import java.util.Comparator;
+import java.util.Optional;
+
+import seedu.address.model.attribute.Attribute;
+
+public class AttributeSortComparator implements Comparator<Person> {
+    private final String attributeName;
+
+    /**
+     * Initializes an instance with an attribute.
+     * The instance will be used to compare two Persons based on the given attribute name.
+     *
+     * @param attributeName The attribute name with which the candidates will be sorted.
+     */
+    public AttributeSortComparator(String attributeName) {
+        this.attributeName = attributeName;
+    }
+
+    @Override
+    public int compare(Person o1, Person o2) {
+        if (o1.isSamePerson(o2)) {
+            return 0;
+        }
+        Optional<Attribute> o1Attribute = o1.getAttribute(attributeName);
+        Optional<Attribute> o2Attribute = o2.getAttribute(attributeName);
+        return o2Attribute.map(value
+                -> o1Attribute.map(attribute
+                        -> attribute.compareToAttributeOfSameAttributeName(value))
+                .orElse(1)).orElse(-1);
+
+    }
+}

--- a/src/main/java/seedu/address/model/person/AttributeSortComparator.java
+++ b/src/main/java/seedu/address/model/person/AttributeSortComparator.java
@@ -1,34 +1,4 @@
 package seedu.address.model.person;
 
-import java.util.Comparator;
-import java.util.Optional;
-
-import seedu.address.model.attribute.Attribute;
-
-public class AttributeSortComparator implements Comparator<Person> {
-    private final String attributeName;
-
-    /**
-     * Initializes an instance with an attribute.
-     * The instance will be used to compare two Persons based on the given attribute name.
-     *
-     * @param attributeName The attribute name with which the candidates will be sorted.
-     */
-    public AttributeSortComparator(String attributeName) {
-        this.attributeName = attributeName;
-    }
-
-    @Override
-    public int compare(Person o1, Person o2) {
-        if (o1.isSamePerson(o2)) {
-            return 0;
-        }
-        Optional<Attribute> o1Attribute = o1.getAttribute(attributeName);
-        Optional<Attribute> o2Attribute = o2.getAttribute(attributeName);
-        return o2Attribute.map(value
-                -> o1Attribute.map(attribute
-                        -> attribute.compareToAttributeOfSameAttributeName(value))
-                .orElse(1)).orElse(-1);
-
-    }
+public class AttributeSortComparator {
 }

--- a/src/main/java/seedu/address/model/person/AttributeSortComparator.java
+++ b/src/main/java/seedu/address/model/person/AttributeSortComparator.java
@@ -1,4 +1,33 @@
 package seedu.address.model.person;
 
-public class AttributeSortComparator {
+import java.util.Comparator;
+import java.util.Optional;
+
+import seedu.address.model.attribute.Attribute;
+
+public class AttributeSortComparator implements Comparator<Person> {
+    private final String attributeName;
+
+    /**
+     * Initializes an instance with an attribute.
+     * The instance will be used to compare two Persons based on the given attribute name.
+     *
+     * @param attributeName The attribute name with which the candidates will be sorted.
+     */
+    public AttributeSortComparator(String attributeName) {
+        this.attributeName = attributeName;
+    }
+
+    @Override
+    public int compare(Person o1, Person o2) {
+        Optional<Attribute> o1Attribute = o1.getAttribute(attributeName);
+        Optional<Attribute> o2Attribute = o2.getAttribute(attributeName);
+        if (o2Attribute.isEmpty()) {
+            return -1;
+        }
+        if (o1Attribute.isEmpty()) {
+            return 1;
+        }
+        return o1Attribute.get().compareToAttributeOfSameAttributeName(o2Attribute.get());
+    }
 }

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -3,6 +3,8 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 
@@ -46,6 +48,10 @@ public class UniquePersonList implements Iterable<Person> {
             throw new DuplicatePersonException();
         }
         internalList.add(toAdd);
+    }
+
+    public void sortPersons(Comparator<Person> comparator) {
+        internalList.sort(comparator);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -18,7 +18,7 @@ import seedu.address.model.person.exceptions.PersonNotFoundException;
  * persons uses Person#isSamePerson(Person) for equality so as to ensure that the person being added or updated is
  * unique in terms of identity in the UniquePersonList. However, the removal of a person uses Person#equals(Object) so
  * as to ensure that the person with exactly the same fields will be removed.
- * <p>
+ *
  * Supports a minimal set of list operations.
  *
  * @see Person#isSamePerson(Person)

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -3,7 +3,6 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
@@ -19,7 +18,7 @@ import seedu.address.model.person.exceptions.PersonNotFoundException;
  * persons uses Person#isSamePerson(Person) for equality so as to ensure that the person being added or updated is
  * unique in terms of identity in the UniquePersonList. However, the removal of a person uses Person#equals(Object) so
  * as to ensure that the person with exactly the same fields will be removed.
- *
+ * <p>
  * Supports a minimal set of list operations.
  *
  * @see Person#isSamePerson(Person)
@@ -122,11 +121,10 @@ public class UniquePersonList implements Iterable<Person> {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof UniquePersonList)) {
+        if (!(other instanceof UniquePersonList otherUniquePersonList)) {
             return false;
         }
 
-        UniquePersonList otherUniquePersonList = (UniquePersonList) other;
         return internalList.equals(otherUniquePersonList.internalList);
     }
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -163,6 +163,10 @@ public class MainWindow extends UiPart<Stage> {
         primaryStage.hide();
     }
 
+    public void setPersonListPanel(PersonListPanel personListPanel) {
+        this.personListPanel = personListPanel;
+    }
+
     public PersonListPanel getPersonListPanel() {
         return personListPanel;
     }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -10,6 +10,7 @@ import static seedu.address.testutil.TypicalPersons.ALICE;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -155,6 +156,11 @@ public class AddCommandTest {
 
         @Override
         public void updateFilteredPersonList(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void sortFilteredPersonList(Comparator<Person> comparator) {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -1,0 +1,4 @@
+package seedu.address.logic.parser;
+
+public class SortCommandParserTest {
+}

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -18,12 +18,6 @@ public class SortCommandParserTest {
     }
 
     @Test
-    public void parse_moreThanOneArgs_throwsParseException() {
-        assertParseFailure(parser, "sort a/GPA a/Age",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
-    }
-
-    @Test
     public void parse_validArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
         SortCommand expectedSortCommand =

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -1,4 +1,39 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ATTRIBUTE;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.SortCommand;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
+
 public class SortCommandParserTest {
+
+    private SortCommandParser parser = new SortCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_moreThanOneArgs_throwsParseException() {
+        assertParseFailure(parser, "sort a/GPA a/Age",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SortCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsFindCommand() {
+        // no leading and trailing whitespaces
+        SortCommand expectedSortCommand =
+                new SortCommand("Graduation Year");
+        assertParseSuccess(parser, "sort a/Graduation Year", expectedSortCommand);
+        assertParseSuccess(parser, "sort a/    Graduation Year   ", expectedSortCommand);
+    }
+
 }

--- a/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SortCommandParserTest.java
@@ -1,20 +1,16 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ATTRIBUTE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-
-import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.SortCommand;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 public class SortCommandParserTest {
 
-    private SortCommandParser parser = new SortCommandParser();
+    private final SortCommandParser parser = new SortCommandParser();
 
     @Test
     public void parse_emptyArg_throwsParseException() {

--- a/src/test/java/seedu/address/model/person/AttributeSortComparatorTest.java
+++ b/src/test/java/seedu/address/model/person/AttributeSortComparatorTest.java
@@ -27,12 +27,12 @@ public class AttributeSortComparatorTest {
     }
 
     @Test
-    public void compare_secondPersonHasAttribute_firstPersonDoesNot_returnsPositive() {
+    public void secondPersonHasAttribute_firstPersonDoesNot_returnsPositive() {
         assertEquals(1, comparator.compare(person3, person2));
     }
 
     @Test
-    public void compare_firstPersonHasAttribute_secondPersonDoesNot_returnsNegative() {
+    public void firstPersonHasAttribute_secondPersonDoesNot_returnsNegative() {
         assertEquals(-1, comparator.compare(person1, person4));
     }
 

--- a/src/test/java/seedu/address/model/person/AttributeSortComparatorTest.java
+++ b/src/test/java/seedu/address/model/person/AttributeSortComparatorTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
 import seedu.address.testutil.PersonBuilder;
 
 public class AttributeSortComparatorTest {
@@ -31,7 +32,7 @@ public class AttributeSortComparatorTest {
     }
 
     @Test
-    public void compare_firstPersonHasAttribute_SecondPersonDoesNot_returnsNegative() {
+    public void compare_firstPersonHasAttribute_secondPersonDoesNot_returnsNegative() {
         assertEquals(-1, comparator.compare(person1, person4));
     }
 

--- a/src/test/java/seedu/address/model/person/AttributeSortComparatorTest.java
+++ b/src/test/java/seedu/address/model/person/AttributeSortComparatorTest.java
@@ -1,0 +1,4 @@
+package seedu.address.model.person;
+
+public class AttributeSortComparatorTest {
+}

--- a/src/test/java/seedu/address/model/person/AttributeSortComparatorTest.java
+++ b/src/test/java/seedu/address/model/person/AttributeSortComparatorTest.java
@@ -1,4 +1,48 @@
 package seedu.address.model.person;
 
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import seedu.address.testutil.PersonBuilder;
+
 public class AttributeSortComparatorTest {
+    private AttributeSortComparator comparator;
+    private Person person1;
+    private Person person2;
+    private Person person3;
+    private Person person4;
+
+    @BeforeEach
+    public void setUp() {
+        String attributeName = "Graduation Year";
+        comparator = new AttributeSortComparator(attributeName);
+
+        person1 = new PersonBuilder().withAttributes(attributeName, "2027").build();
+        person2 = new PersonBuilder().withAttributes(attributeName, "2028").build();
+        person3 = new PersonBuilder().withAttributes("GPA", "4.5").build();
+        person4 = new PersonBuilder().withAttributes("Location", "Singapore").build();
+    }
+
+    @Test
+    public void compare_secondPersonHasAttribute_firstPersonDoesNot_returnsPositive() {
+        assertEquals(1, comparator.compare(person3, person2));
+    }
+
+    @Test
+    public void compare_firstPersonHasAttribute_SecondPersonDoesNot_returnsNegative() {
+        assertEquals(-1, comparator.compare(person1, person4));
+    }
+
+    @Test
+    public void compare_bothDoNotHaveAttribute_returnsZero() {
+        assertEquals(-1, comparator.compare(person3, person4)); // Matches your logic
+    }
+
+    @Test
+    public void compare_attributesDifferent_returnsCorrectComparison() {
+        assertEquals(-1, comparator.compare(person1, person2));
+        assertEquals(1, comparator.compare(person2, person1));
+    }
 }


### PR DESCRIPTION
Fixes #84 

Current state of this:
- So it turns out the immutable filtered list is the one that always reflects on GUI, so instead of having a separate sorted list I just modified everything on the filtered list (i.e., now filter and sort can stack on each other)
- But because filtered list cannot be sort (I tried changing the backing list also, but it seems to be immutable so I can't sort it or set it to another list), I am now sorting AddressBook directly
- So now the issue is we can't revert back to the default order for list command, though I believe this can be fixed by adding an index field to Person reflecting the add sequence, then we can sort AddressBook again by the index field for each list command