### PR TITLE
Fix logic for updating personList

### DIFF
--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -122,9 +122,6 @@ public class ModelManager implements Model {
     @Override
     public void updateAlias(String attributeName, Optional<String> siteLink) {
         addressBook.updateAlias(attributeName, siteLink);
-
-        // Supplies a "different" predicate so that the GUI updates
-        updateFilteredPersonList(x -> true);
         updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
     }
 
@@ -146,6 +143,9 @@ public class ModelManager implements Model {
     @Override
     public void updateFilteredPersonList(Predicate<Person> predicate) {
         requireNonNull(predicate);
+
+        // Supplies a different predicate object so that the GUI updates
+        filteredPersons.setPredicate(x -> false);
         filteredPersons.setPredicate(predicate);
     }
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -206,8 +206,8 @@ public class MainWindow extends UiPart<Stage> {
                 handleExit();
             }
 
-            commandResult.getPersonToShow().ifPresentOrElse(person -> personListPanel.showPerson(person), (
-                    ) -> personListPanel.showLastPerson());
+            commandResult.getPersonToShow().ifPresentOrElse(
+                    person -> personListPanel.showPerson(person), () -> personListPanel.showLastPerson());
 
             return commandResult;
         } catch (CommandException | ParseException e) {

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -192,6 +192,8 @@ public class MainWindow extends UiPart<Stage> {
      */
     private CommandResult executeCommand(String commandText) throws CommandException, ParseException {
         try {
+            personListPanel.updateLastShown();
+
             CommandResult commandResult = logic.execute(commandText);
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
@@ -204,7 +206,8 @@ public class MainWindow extends UiPart<Stage> {
                 handleExit();
             }
 
-            commandResult.getPersonToShow().ifPresent(person -> personListPanel.showPerson(person));
+            commandResult.getPersonToShow().ifPresentOrElse(person -> personListPanel.showPerson(person), (
+                    ) -> personListPanel.showLastPerson());
 
             return commandResult;
         } catch (CommandException | ParseException e) {

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -20,6 +20,9 @@ public class PersonListPanel extends UiPart<Region> {
     @FXML
     private ListView<Person> personListView;
 
+    private Person lastShownPerson;
+    private int lastShownIndex;
+
     /**
      * Creates a {@code PersonListPanel} with the given {@code ObservableList}.
      */
@@ -27,6 +30,9 @@ public class PersonListPanel extends UiPart<Region> {
         super(FXML);
         personListView.setItems(personList);
         personListView.setCellFactory(listView -> new PersonListViewCell());
+
+        lastShownPerson = null;
+        lastShownIndex = -1;
     }
 
     /**
@@ -56,6 +62,46 @@ public class PersonListPanel extends UiPart<Region> {
     public void showPerson(Person person) {
         personListView.scrollTo(person);
         personListView.getSelectionModel().select(person);
+
+        lastShownPerson = person;
+        lastShownIndex = personListView.getSelectionModel().getSelectedIndex();
+    }
+
+    /**
+     * Show last shown person.
+     */
+    public void showLastPerson() {
+        ObservableList<Person> list = personListView.getItems();
+        assert list != null;
+
+        if (lastShownPerson != null) {
+            if (list.contains(lastShownPerson)) {
+                showPerson(lastShownPerson);
+            } else if (lastShownIndex < list.size() && lastShownIndex >= 0) {
+                showPerson(list.get(lastShownIndex));
+            } else {
+                resetLastShown();
+            }
+        } else {
+            resetLastShown();
+        }
+    }
+
+    /**
+     * Updates data about last shown person.
+     */
+    public void updateLastShown() {
+        lastShownPerson = personListView.getSelectionModel().getSelectedItem();
+        lastShownIndex = personListView.getSelectionModel().getSelectedIndex();
+    }
+
+    /**
+     * Reset data about last shown person, and deselects any currently selected Person.
+     */
+    private void resetLastShown() {
+        lastShownPerson = null;
+        lastShownIndex = -1;
+        personListView.getSelectionModel().clearSelection();
     }
 
 }


### PR DESCRIPTION
Fixes #209 and #246.

Forces the GUI to update each time `Model::updateFilteredPersonList` is called. To mitigate the issue of de-selecting, some changes were made to `MainWindow` and `PersonListView`.