### PR TITLE
Fix validation of duplicate attribute names in JSON data

### DIFF
--- a/src/main/java/seedu/address/storage/JsonAdaptedAttribute.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedAttribute.java
@@ -39,7 +39,7 @@ class JsonAdaptedAttribute {
     }
 
     public String getAttributeName() {
-        return attributeName;
+        return attributeName.toLowerCase();
     }
 
     public String getAttributeValue() {


### PR DESCRIPTION
Fixes #215 

Seems we forgot to update getAttributeName() to return lowercase attributeName in the JsonAdaptedAttribute. Now matches the behaviour of Attribute class.