### PR TITLE
Remove sucess message for sort commands with nothing to sort.

### DIFF
--- a/src/main/java/seedu/address/logic/commands/NumSortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NumSortCommand.java
@@ -25,7 +25,8 @@ public class NumSortCommand extends SortCommand {
     public static final String MESSAGE_WARNING_PARTIALLY_MISSING_NUMERICALS =
             "WARNING! Only entries up to index %1$d have valid numerical values for the specified attribute name.\n";
     public static final String MESSAGE_WARNING_MISSING_NUMERICALS =
-            "WARNING! No entries have valid numerical values for the specified attribute name.\n";
+            "WARNING! No entries have valid numerical values for the specified attribute name.\n"
+            + "Entries with the specified attribute name have been moved to the front of the list.";
 
 
     /**
@@ -49,6 +50,7 @@ public class NumSortCommand extends SortCommand {
         String warning = super.getWarningMessage(model);
         if (count.isPresent()) {
             if (count.get() == 0) {
+                hasNothingToSort = true;
                 warning += MESSAGE_WARNING_MISSING_NUMERICALS;
             } else {
                 warning += String.format(MESSAGE_WARNING_PARTIALLY_MISSING_NUMERICALS, count.get());

--- a/src/main/java/seedu/address/logic/commands/NumSortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NumSortCommand.java
@@ -49,6 +49,7 @@ public class NumSortCommand extends SortCommand {
         String warning = super.getWarningMessage(model);
         if (count.isPresent()) {
             if (count.get() == 0) {
+                hasNothingToSort = true;
                 warning += MESSAGE_WARNING_MISSING_NUMERICALS;
             } else {
                 warning += String.format(MESSAGE_WARNING_PARTIALLY_MISSING_NUMERICALS, count.get());

--- a/src/main/java/seedu/address/logic/commands/NumSortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NumSortCommand.java
@@ -49,7 +49,6 @@ public class NumSortCommand extends SortCommand {
         String warning = super.getWarningMessage(model);
         if (count.isPresent()) {
             if (count.get() == 0) {
-                hasNothingToSort = true;
                 warning += MESSAGE_WARNING_MISSING_NUMERICALS;
             } else {
                 warning += String.format(MESSAGE_WARNING_PARTIALLY_MISSING_NUMERICALS, count.get());

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -20,8 +20,8 @@ public abstract class SortCommand extends Command {
 
     protected final String attributeName;
     protected Optional<String> adjustedAttributeName;
-    private final boolean isAscending;
     protected boolean hasNothingToSort;
+    private final boolean isAscending;
 
     /**
      * Initializes an instance with the comparator based on the attribute name.

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -47,12 +47,16 @@ public abstract class SortCommand extends Command {
     public String getWarningMessage(Model model) {
         Optional<String> missingAttributeWarning =
             AutoCorrectionUtil.getWarningForName(attributeName, adjustedAttributeName);
-        if (missingAttributeWarning.isPresent()) { //No entry has the specified attribute name
+        String message = "";
+        if (missingAttributeWarning.isPresent()) {
+            message += missingAttributeWarning.get() + "\n";
+        }
+        if (adjustedAttributeName.isEmpty()) {
             hasNothingToSort = true;
-            return missingAttributeWarning.get() + "\n";
+            return message;
         }
         Optional<Long> count = model.numOfPersonsWithAttribute(this.adjustedAttributeName.orElse(attributeName));
-        return count.map(val -> String.format(MESSAGE_WARNING_MISSING_ATTRIBUTE, val)).orElse("");
+        return message + count.map(val -> String.format(MESSAGE_WARNING_MISSING_ATTRIBUTE, val)).orElse("");
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -21,6 +21,7 @@ public abstract class SortCommand extends Command {
     protected final String attributeName;
     protected Optional<String> adjustedAttributeName;
     private final boolean isAscending;
+    protected boolean hasNothingToSort;
 
     /**
      * Initializes an instance with the comparator based on the attribute name.
@@ -31,6 +32,7 @@ public abstract class SortCommand extends Command {
         requireNonNull(attributeName);
         this.attributeName = attributeName;
         this.isAscending = isAscending;
+        this.hasNothingToSort = false;
     }
 
     /**
@@ -46,6 +48,7 @@ public abstract class SortCommand extends Command {
         Optional<String> missingAttributeWarning =
             AutoCorrectionUtil.getWarningForName(attributeName, adjustedAttributeName);
         if (missingAttributeWarning.isPresent()) { //No entry has the specified attribute name
+            hasNothingToSort = true;
             return missingAttributeWarning.get() + "\n";
         }
         Optional<Long> count = model.numOfPersonsWithAttribute(this.adjustedAttributeName.orElse(attributeName));
@@ -59,6 +62,9 @@ public abstract class SortCommand extends Command {
         this.adjustedAttributeName = model.autocorrectAttributeName(this.attributeName);
         model.sortFilteredPersonList(this.getComparator(this.isAscending));
         String message = this.getWarningMessage(model);
+        if (hasNothingToSort) {
+            return new CommandResult(message);
+        }
         if (this.isAscending) {
             message += String.format(Messages.MESSAGE_PERSONS_SORTED_OVERVIEW, "ascending");
         } else {


### PR DESCRIPTION
Fixes #347 
Fix done in last commit: I originally made it omit success message if no entry has numerical values, but after a second thought i realise sort-num would still put entries with the specified attribute name at the front. so now, the only case where we omit success message for both sort and sort-num is when no entry has the specified attribute name.
Do we need to update UG for this? I feel no need cuz we never mentioned the success message anw